### PR TITLE
Remove button-row (for now)

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@ category: home
 	</div>
 </div>
 
+<!--
 <div class="button-row">
 	<div class="container-fluid">
 		<div class="row">
@@ -52,6 +53,7 @@ category: home
 		</div>
 	</div>
 </div>
+-->
 
 <div class="blurb">
 	<div class="container-fluid">

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@ category: home
 				<img class="img-responsive" src="assets/img/workshop_arthur.jpg" alt="Arthur teaching a workshop"/>
 			</div>
 			<div class="col-md-8">
+				<h3>About</h3>
 				<p><a href="https://carpentries.org">The Carpentries</a> is an international organization that offers two-day workshops that emphasize using best practices for engaging in reproducible data analysis. A typical workshop will introduce learners to the command line, version control, computer programming, and data hygeine. Our <a href="https://software-carpentry.org">Software Carpentry</a> and <a href="https://datacarpentry.org">Data Carpentry</a> workshops following curricula that are developed collaboratively and using the latest research into best practices for teaching computer science content. All of our workshops are offered for free to learners. We strive to foster a growth mindset in learners by hosting an inclusive learning environment with instructors who are representative of our learners.</p>
 
 				<p>If you are interested in learning more about taking one of our upcoming workshops or would like to learn how to host a workshop for your department or program, feel free to <a href="mailto:{{ site.email }}">contact us</a> with any questions. If you have already participated in a workshop or are interested in helping to teach a workshop, please let us know by <a href="https://forms.gle/pwvyUDmPyChtdneg8">completing a brief survey</a>.</p>


### PR DESCRIPTION
It doesn't look great to have "picture coming soon" on the homepage.
I propose we remove the buttons for now, and add them back once we have pictures or icons to use.
We should probably also either keep the News page up-to-date or remove it.